### PR TITLE
solved the windows issue with symlinks

### DIFF
--- a/install.js
+++ b/install.js
@@ -5,7 +5,7 @@
 //
 var fs = require('fs')
   , path = require('path')
-  , spawn = require('cross-spawn')
+  , os = require('os')
   , hook = path.join(__dirname, 'hook')
   , root = path.resolve(__dirname, '..', '..')
   , exists = fs.existsSync || path.existsSync;
@@ -47,15 +47,30 @@ if (exists(precommit) && !fs.lstatSync(precommit).isSymbolicLink()) {
 try { fs.unlinkSync(precommit); }
 catch (e) {}
 
+// Create generic precommit hook that launches this modules hook (as well
+// as stashing - unstashing the unstaged changes)
+// TODO: we could keep launching the old pre-commit scripts
+var hookRelativeUnixPath = hook.replace(root, '.');
+if(os.platform() === 'win32') {
+  hookRelativeUnixPath = hookRelativeUnixPath.replace(/[\\\/]+/g, '/');
+}
+var precommitContent = '#!/bin/bash' + os.EOL
+  + 'git stash -q --keep-index' + os.EOL
+  +  hookRelativeUnixPath + os.EOL
+  + 'RESULT=$?' + os.EOL
+  + 'git stash pop -q' + os.EOL
+  + '[ $RESULT -ne 0 ] && exit 1' + os.EOL
+  + 'exit 0' + os.EOL;
+
 //
 // It could be that we do not have rights to this folder which could cause the
 // installation of this module to completely fail. We should just output the
 // error instead destroying the whole npm install process.
 //
-try { fs.symlinkSync(path.relative(hooks, hook), precommit, 'file'); }
+try { fs.writeFileSync(precommit, precommitContent); }
 catch (e) {
   console.error('pre-commit:');
-  console.error('pre-commit: Failed to symlink the hook file in your .git/hooks folder because:');
+  console.error('pre-commit: Failed to create the hook file in your .git/hooks folder because:');
   console.error('pre-commit: '+ e.message);
   console.error('pre-commit: The hook was not installed.');
   console.error('pre-commit:');

--- a/install.js
+++ b/install.js
@@ -55,10 +55,8 @@ if(os.platform() === 'win32') {
   hookRelativeUnixPath = hookRelativeUnixPath.replace(/[\\\/]+/g, '/');
 }
 var precommitContent = '#!/bin/bash' + os.EOL
-  + 'git stash -q --keep-index' + os.EOL
   +  hookRelativeUnixPath + os.EOL
   + 'RESULT=$?' + os.EOL
-  + 'git stash pop -q' + os.EOL
   + '[ $RESULT -ne 0 ] && exit 1' + os.EOL
   + 'exit 0' + os.EOL;
 


### PR DESCRIPTION
Instead of symlinking to the hook in node-modules/pre-commit, this injects a new pre-commit hook (in .git/hooks) that takes care of launching the hook in node-modules/pre-commit. 
In addition it stashes the unstaged changes and applies them again after running the pre-commit hook, so that you only run your pre-commit scripts on the commit actual codebase.